### PR TITLE
perf: call with_recorder only once

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -46,18 +46,28 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                                 metrics_attr.separator(),
                                 metric.name()
                             );
-                            let registrar = metric.register_stmt()?;
-                            let describe = metric.describe_stmt()?;
+                            let register_method = metric.register_method()?;
+                            let describe_method = metric.describe_method()?;
                             let description = &metric.description;
                             Ok((
                                 quote! {
-                                    #field_name: #registrar(#metric_name),
+                                    #field_name: {
+                                        static METRIC_KEY: ::metrics::Key = ::metrics::Key::from_static_name(#metric_name);
+                                        __recorder.#register_method(&METRIC_KEY, __metadata)
+                                    },
                                 },
                                 quote! {
-                                    #field_name: #registrar(#metric_name, labels.clone()),
+                                    #field_name: __recorder.#register_method(
+                                        &::metrics::Key::from_parts(#metric_name, __labels.clone()),
+                                        __metadata,
+                                    ),
                                 },
                                 Some(quote! {
-                                    #describe(#metric_name, #description);
+                                    __recorder.#describe_method(
+                                        ::core::convert::Into::into(#metric_name),
+                                        ::core::option::Option::None,
+                                        ::core::convert::Into::into(#description),
+                                    );
                                 }),
                             ))
                         }
@@ -88,23 +98,42 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                     fn default() -> Self {
                         #ty::describe();
 
-                        Self {
-                            #(#defaults)*
-                        }
+                        ::metrics::with_recorder(|__recorder| {
+                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+                                module_path!(),
+                                ::metrics::Level::INFO,
+                                ::core::option::Option::Some(module_path!()),
+                            );
+                            let __metadata = &__METADATA;
+                            Self {
+                                #(#defaults)*
+                            }
+                        })
                     }
                 }
 
                 impl #ty {
                     /// Create new instance of metrics with provided labels.
-                    #vis fn new_with_labels(labels: impl metrics::IntoLabels + Clone) -> Self {
-                        Self {
-                            #(#labeled_defaults)*
-                        }
+                    #vis fn new_with_labels(labels: impl ::metrics::IntoLabels + Clone) -> Self {
+                        ::metrics::with_recorder(|__recorder| {
+                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+                                module_path!(),
+                                ::metrics::Level::INFO,
+                                ::core::option::Option::Some(module_path!()),
+                            );
+                            let __metadata = &__METADATA;
+                            let __labels = labels;
+                            Self {
+                                #(#labeled_defaults)*
+                            }
+                        })
                     }
 
                     #describe_doc
                     #vis fn describe() {
-                        #(#describes)*
+                        ::metrics::with_recorder(|__recorder| {
+                            #(#describes)*
+                        });
                     }
                 }
             }
@@ -118,23 +147,33 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                         MetricField::Included(metric) => {
                             let name = metric.name();
                             let separator = metrics_attr.separator();
-                            let metric_name = quote! {
-                                format!("{}{}{}", scope, #separator, #name)
-                            };
 
-                            let registrar = metric.register_stmt()?;
-                            let describe = metric.describe_stmt()?;
+                            let register_method = metric.register_method()?;
+                            let describe_method = metric.describe_method()?;
                             let description = &metric.description;
 
                             Ok((
                                 quote! {
-                                    #field_name: #registrar(#metric_name),
+                                    #field_name: __recorder.#register_method(
+                                        &::metrics::Key::from_name(format!("{}{}{}", __scope, #separator, #name)),
+                                        __metadata,
+                                    ),
                                 },
                                 quote! {
-                                    #field_name: #registrar(#metric_name, labels.clone()),
+                                    #field_name: __recorder.#register_method(
+                                        &::metrics::Key::from_parts(
+                                            format!("{}{}{}", __scope, #separator, #name),
+                                            __labels.clone(),
+                                        ),
+                                        __metadata,
+                                    ),
                                 },
                                 Some(quote! {
-                                    #describe(#metric_name, #description);
+                                    __recorder.#describe_method(
+                                        ::core::convert::Into::into(format!("{}{}{}", __scope, #separator, #name)),
+                                        ::core::option::Option::None,
+                                        ::core::convert::Into::into(#description),
+                                    );
                                 }),
                             ))
                         }
@@ -166,21 +205,43 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                     #vis fn new(scope: &str) -> Self {
                         #ty::describe(scope);
 
-                        Self {
-                            #(#defaults)*
-                        }
+                        ::metrics::with_recorder(|__recorder| {
+                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+                                module_path!(),
+                                ::metrics::Level::INFO,
+                                ::core::option::Option::Some(module_path!()),
+                            );
+                            let __metadata = &__METADATA;
+                            let __scope = scope;
+                            Self {
+                                #(#defaults)*
+                            }
+                        })
                     }
 
                     /// Create new instance of metrics with provided labels.
-                    #vis fn new_with_labels(scope: &str, labels: impl metrics::IntoLabels + Clone) -> Self {
-                        Self {
-                            #(#labeled_defaults)*
-                        }
+                    #vis fn new_with_labels(scope: &str, labels: impl ::metrics::IntoLabels + Clone) -> Self {
+                        ::metrics::with_recorder(|__recorder| {
+                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+                                module_path!(),
+                                ::metrics::Level::INFO,
+                                ::core::option::Option::Some(module_path!()),
+                            );
+                            let __metadata = &__METADATA;
+                            let __scope = scope;
+                            let __labels = labels;
+                            Self {
+                                #(#labeled_defaults)*
+                            }
+                        })
                     }
 
                     #describe_doc
                     #vis fn describe(scope: &str) {
-                        #(#describes)*
+                        ::metrics::with_recorder(|__recorder| {
+                            let __scope = scope;
+                            #(#describes)*
+                        });
                     }
                 }
             }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -86,7 +86,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
             quote! {
                 impl Default for #ty {
                     fn default() -> Self {
-                        #ty::f();
+                        #ty::describe();
                         #ty::new_with_labels(::core::slice::Iter::<'_, ::metrics::Label>::default())
                     }
                 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -34,7 +34,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
     };
     let register_and_describe = match &metrics_attr.scope {
         MetricsScope::Static(scope) => {
-            let (defaults, labeled_defaults, describes): (Vec<_>, Vec<_>, Vec<_>) = metric_fields
+            let (field_inits, describes): (Vec<_>, Vec<_>) = metric_fields
                 .iter()
                 .map(|metric| {
                     let field_name = &metric.field().ident;
@@ -50,12 +50,6 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             let describe_method = metric.describe_method()?;
                             let description = &metric.description;
                             Ok((
-                                quote! {
-                                    #field_name: {
-                                        static METRIC_KEY: ::metrics::Key = ::metrics::Key::from_static_name(#metric_name);
-                                        __recorder.#register_method(&METRIC_KEY, __metadata)
-                                    },
-                                },
                                 quote! {
                                     #field_name: __recorder.#register_method(
                                         &::metrics::Key::from_parts(#metric_name, __labels.clone()),
@@ -75,20 +69,16 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             quote! {
                                 #field_name: Default::default(),
                             },
-                            quote! {
-                                #field_name: Default::default(),
-                            },
                             None,
                         )),
                     }
                 })
                 .collect::<Result<Vec<_>>>()?
                 .into_iter()
-                .fold((vec![], vec![], vec![]), |mut acc, x| {
+                .fold((vec![], vec![]), |mut acc, x| {
                     acc.0.push(x.0);
-                    acc.1.push(x.1);
-                    if let Some(describe) = x.2 {
-                        acc.2.push(describe);
+                    if let Some(describe) = x.1 {
+                        acc.1.push(describe);
                     }
                     acc
                 });
@@ -96,19 +86,8 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
             quote! {
                 impl Default for #ty {
                     fn default() -> Self {
-                        #ty::describe();
-
-                        ::metrics::with_recorder(|__recorder| {
-                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
-                                module_path!(),
-                                ::metrics::Level::INFO,
-                                ::core::option::Option::Some(module_path!()),
-                            );
-                            let __metadata = &__METADATA;
-                            Self {
-                                #(#defaults)*
-                            }
-                        })
+                        #ty::f();
+                        #ty::new_with_labels(::core::slice::Iter::<'_, ::metrics::Label>::default())
                     }
                 }
 
@@ -124,7 +103,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             let __metadata = &__METADATA;
                             let __labels = labels;
                             Self {
-                                #(#labeled_defaults)*
+                                #(#field_inits)*
                             }
                         })
                     }
@@ -139,7 +118,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
             }
         }
         MetricsScope::Dynamic => {
-            let (defaults, labeled_defaults, describes): (Vec<_>, Vec<_>, Vec<_>) = metric_fields
+            let (field_inits, describes): (Vec<_>, Vec<_>) = metric_fields
                 .iter()
                 .map(|metric| {
                     let field_name = &metric.field().ident;
@@ -153,12 +132,6 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             let description = &metric.description;
 
                             Ok((
-                                quote! {
-                                    #field_name: __recorder.#register_method(
-                                        &::metrics::Key::from_name(format!("{}{}{}", __scope, #separator, #name)),
-                                        __metadata,
-                                    ),
-                                },
                                 quote! {
                                     #field_name: __recorder.#register_method(
                                         &::metrics::Key::from_parts(
@@ -181,20 +154,16 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             quote! {
                                 #field_name: Default::default(),
                             },
-                            quote! {
-                                #field_name: Default::default(),
-                            },
                             None,
                         )),
                     }
                 })
                 .collect::<Result<Vec<_>>>()?
                 .into_iter()
-                .fold((vec![], vec![], vec![]), |mut acc, x| {
+                .fold((vec![], vec![]), |mut acc, x| {
                     acc.0.push(x.0);
-                    acc.1.push(x.1);
-                    if let Some(describe) = x.2 {
-                        acc.2.push(describe);
+                    if let Some(describe) = x.1 {
+                        acc.1.push(describe);
                     }
                     acc
                 });
@@ -202,21 +171,11 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
             quote! {
                 impl #ty {
                     /// Create new instance of metrics with provided scope.
+                    ///
+                    /// This will also register the metrics with the global recorder.
                     #vis fn new(scope: &str) -> Self {
                         #ty::describe(scope);
-
-                        ::metrics::with_recorder(|__recorder| {
-                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
-                                module_path!(),
-                                ::metrics::Level::INFO,
-                                ::core::option::Option::Some(module_path!()),
-                            );
-                            let __metadata = &__METADATA;
-                            let __scope = scope;
-                            Self {
-                                #(#defaults)*
-                            }
-                        })
+                        #ty::new_with_labels(scope, ::core::slice::Iter::<'_, ::metrics::Label>::default())
                     }
 
                     /// Create new instance of metrics with provided labels.
@@ -231,7 +190,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                             let __scope = scope;
                             let __labels = labels;
                             Self {
-                                #(#labeled_defaults)*
+                                #(#field_inits)*
                             }
                         })
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(issue_tracker_base_url = "https://github.com/rkrasiuk/metrics-derive/issues/")]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -23,34 +23,34 @@ impl<'a> Metric<'a> {
         }
     }
 
-    pub(crate) fn register_stmt(&self) -> Result<proc_macro2::TokenStream> {
+    pub(crate) fn register_method(&self) -> Result<proc_macro2::TokenStream> {
         if let Type::Path(ref path_ty) = self.field.ty {
             if let Some(last) = path_ty.path.segments.last() {
-                let registrar = match last.ident.to_string().as_str() {
-                    COUNTER_TY => quote! { metrics::counter! },
-                    HISTOGRAM_TY => quote! { metrics::histogram! },
-                    GAUGE_TY => quote! { metrics::gauge! },
+                let method = match last.ident.to_string().as_str() {
+                    COUNTER_TY => quote! { register_counter },
+                    HISTOGRAM_TY => quote! { register_histogram },
+                    GAUGE_TY => quote! { register_gauge },
                     _ => return Err(Error::new_spanned(path_ty, "unsupported metric type")),
                 };
 
-                return Ok(quote! { #registrar });
+                return Ok(method);
             }
         }
 
         Err(Error::new_spanned(&self.field.ty, "unsupported metric type"))
     }
 
-    pub(crate) fn describe_stmt(&self) -> Result<proc_macro2::TokenStream> {
+    pub(crate) fn describe_method(&self) -> Result<proc_macro2::TokenStream> {
         if let Type::Path(ref path_ty) = self.field.ty {
             if let Some(last) = path_ty.path.segments.last() {
-                let descriptor = match last.ident.to_string().as_str() {
-                    COUNTER_TY => quote! { metrics::describe_counter! },
-                    HISTOGRAM_TY => quote! { metrics::describe_histogram! },
-                    GAUGE_TY => quote! { metrics::describe_gauge! },
+                let method = match last.ident.to_string().as_str() {
+                    COUNTER_TY => quote! { describe_counter },
+                    HISTOGRAM_TY => quote! { describe_histogram },
+                    GAUGE_TY => quote! { describe_gauge },
                     _ => return Err(Error::new_spanned(path_ty, "unsupported metric type")),
                 };
 
-                return Ok(quote! { #descriptor });
+                return Ok(method);
             }
         }
 


### PR DESCRIPTION
Reduces generated code and improves runtime performance