### PR TITLE
perf: call with_recorder only once per method

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+t = "nextest run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,65 +1,66 @@
 name: CI
 
 on:
-    push:
-        branches: [main]
-    pull_request:
+  push:
+    branches: [main]
+  pull_request:
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    test:
-        name: test ${{ matrix.rust }}
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        strategy:
-            fail-fast: false
-            matrix:
-                rust: ["stable", "beta", "nightly", "1.80"]
-        steps:
-            - uses: actions/checkout@v3
-            - uses: dtolnay/rust-toolchain@master
-              with:
-                  toolchain: ${{ matrix.rust }}
-            - uses: Swatinem/rust-cache@v2
-              with:
-                  cache-on-failure: true
-            - uses: taiki-e/install-action@nextest
-            - run: cargo nextest run --workspace
+  test:
+    name: test ${{ matrix.rust }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ["stable", "beta", "nightly", "1.80"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@nextest
+      - run: cargo build --workspace
+      - run: cargo nextest run --workspace
 
-    clippy:
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - uses: actions/checkout@v3
-            - uses: dtolnay/rust-toolchain@clippy
-            - uses: Swatinem/rust-cache@v2
-              with:
-                  cache-on-failure: true
-            - run: cargo clippy --workspace --all-targets --all-features
-              env:
-                  RUSTFLAGS: -Dwarnings
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -Dwarnings
 
-    docs:
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - uses: actions/checkout@v3
-            - uses: dtolnay/rust-toolchain@nightly
-            - uses: Swatinem/rust-cache@v2
-              with:
-                  cache-on-failure: true
-            - run: cargo doc --workspace --all-features --no-deps --document-private-items
-              env:
-                  RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo doc --workspace --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 
-    fmt:
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - uses: actions/checkout@v3
-            - uses: dtolnay/rust-toolchain@nightly
-              with:
-                  components: rustfmt
-            - run: cargo fmt --all --check
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,8 @@ jobs:
             - uses: Swatinem/rust-cache@v2
               with:
                   cache-on-failure: true
-            - name: build
-              run: cargo build --workspace
-            - name: test
-              run: cargo test --workspace
+            - uses: taiki-e/install-action@nextest
+            - run: cargo nextest run --workspace
 
     clippy:
         runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ syn = "2.0"
 
 [dev-dependencies]
 metrics = "0.24.0"
-serial_test = "3"
 trybuild = "1.0"

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -83,17 +83,42 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                     acc
                 });
 
+            let clone_fields: Vec<_> = metric_fields
+                .iter()
+                .map(|m| {
+                    let field_name = &m.field().ident;
+                    quote! { #field_name: ::core::clone::Clone::clone(&self.#field_name), }
+                })
+                .collect();
+
             quote! {
                 impl Default for #ty {
                     fn default() -> Self {
-                        #ty::describe();
-                        #ty::new_with_labels(::core::slice::Iter::<'_, ::metrics::Label>::default())
+                        Self::new()
                     }
                 }
 
                 impl #ty {
-                    /// Create new instance of metrics with provided labels.
+                    /// Creates a new instance of the metrics.
+                    ///
+                    /// This initializes all metrics and registers them with the global recorder.
+                    /// Metrics are described and registered only once; subsequent calls return
+                    /// a clone of the initially registered metrics.
+                    ///
+                    /// To re-register or register with labels, use [`Self::new_with_labels`].
+                    #vis fn new() -> Self {
+                        static __REGISTER_ONCE: ::std::sync::OnceLock<#ty> = ::std::sync::OnceLock::new();
+                        __REGISTER_ONCE.get_or_init(|| {
+                            Self::new_with_labels(::std::vec::Vec::<::metrics::Label>::new())
+                        })._clone()
+                    }
+
+                    /// Creates a new instance of the metrics with the provided labels.
+                    ///
+                    /// Unlike [`Self::new`], this does not cache the result, so it can be used
+                    /// to re-register metrics or register with different labels.
                     #vis fn new_with_labels(labels: impl ::metrics::IntoLabels + Clone) -> Self {
+                        Self::describe();
                         ::metrics::with_recorder(|__recorder| {
                             static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
                                 module_path!(),
@@ -110,9 +135,19 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 
                     #describe_doc
                     #vis fn describe() {
+                        static __DESCRIBE_ONCE: ::std::sync::Once = ::std::sync::Once::new();
+                        __DESCRIBE_ONCE.call_once(Self::force_describe);
+                    }
+
+                    /// Unconditionally describes all metrics.
+                    #vis fn force_describe() {
                         ::metrics::with_recorder(|__recorder| {
                             #(#describes)*
                         });
+                    }
+
+                    fn _clone(&self) -> Self {
+                        Self { #(#clone_fields)* }
                     }
                 }
             }
@@ -170,16 +205,29 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 
             quote! {
                 impl #ty {
-                    /// Create new instance of metrics with provided scope.
+                    /// Creates a new instance of the metrics with the provided scope.
                     ///
-                    /// This will also register the metrics with the global recorder.
+                    /// This initializes all metrics and registers them with the global recorder.
                     #vis fn new(scope: &str) -> Self {
-                        #ty::describe(scope);
-                        #ty::new_with_labels(scope, ::core::slice::Iter::<'_, ::metrics::Label>::default())
+                        Self::describe(scope);
+                        ::metrics::with_recorder(|__recorder| {
+                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+                                module_path!(),
+                                ::metrics::Level::INFO,
+                                ::core::option::Option::Some(module_path!()),
+                            );
+                            let __metadata = &__METADATA;
+                            let __scope = scope;
+                            let __labels = ::std::vec::Vec::<::metrics::Label>::new();
+                            Self {
+                                #(#field_inits)*
+                            }
+                        })
                     }
 
-                    /// Create new instance of metrics with provided labels.
+                    /// Creates a new instance of the metrics with the provided scope and labels.
                     #vis fn new_with_labels(scope: &str, labels: impl ::metrics::IntoLabels + Clone) -> Self {
+                        Self::describe(scope);
                         ::metrics::with_recorder(|__recorder| {
                             static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
                                 module_path!(),
@@ -197,6 +245,11 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 
                     #describe_doc
                     #vis fn describe(scope: &str) {
+                        Self::force_describe(scope);
+                    }
+
+                    /// Unconditionally describes all metrics.
+                    #vis fn force_describe(scope: &str) {
                         ::metrics::with_recorder(|__recorder| {
                             let __scope = scope;
                             #(#describes)*
@@ -206,11 +259,12 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
             }
         }
     };
+
     Ok(quote! {
         #register_and_describe
 
-        impl std::fmt::Debug for #ty {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl ::core::fmt::Debug for #ty {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.debug_struct(#ident_name).finish()
             }
         }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -210,19 +210,7 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
                     /// This initializes all metrics and registers them with the global recorder.
                     #vis fn new(scope: &str) -> Self {
                         Self::describe(scope);
-                        ::metrics::with_recorder(|__recorder| {
-                            static __METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
-                                module_path!(),
-                                ::metrics::Level::INFO,
-                                ::core::option::Option::Some(module_path!()),
-                            );
-                            let __metadata = &__METADATA;
-                            let __scope = scope;
-                            let __labels = ::std::vec::Vec::<::metrics::Label>::new();
-                            Self {
-                                #(#field_inits)*
-                            }
-                        })
+                        Self::new_with_labels(scope, ::std::vec::Vec::<::metrics::Label>::new())
                     }
 
                     /// Creates a new instance of the metrics with the provided scope and labels.
@@ -245,11 +233,6 @@ pub(crate) fn derive(node: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 
                     #describe_doc
                     #vis fn describe(scope: &str) {
-                        Self::force_describe(scope);
-                    }
-
-                    /// Unconditionally describes all metrics.
-                    #vis fn force_describe(scope: &str) {
                         ::metrics::with_recorder(|__recorder| {
                             let __scope = scope;
                             #(#describes)*

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,3 +1,5 @@
+// Use `cargo nextest` to run tests.
+
 #![allow(missing_docs)]
 use metrics::{
     Counter, Gauge, Histogram, Key, KeyName, Label, Metadata, Recorder, SharedString, Unit,

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 #[allow(dead_code)]
-#[derive(Metrics)]
+#[derive(Clone, Metrics)]
 #[metrics(scope = "metrics_custom")]
 struct CustomMetrics {
     #[metric(skip)]

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -3,7 +3,6 @@ use metrics::{
     Counter, Gauge, Histogram, Key, KeyName, Label, Metadata, Recorder, SharedString, Unit,
 };
 use metrics_derive::Metrics;
-use serial_test::serial;
 use std::{
     collections::HashMap,
     sync::{LazyLock, Mutex},
@@ -114,7 +113,6 @@ fn test_describe(scope: &str) {
 }
 
 #[test]
-#[serial]
 fn describe_metrics() {
     let _guard = RECORDER.enter();
 
@@ -124,7 +122,6 @@ fn describe_metrics() {
 }
 
 #[test]
-#[serial]
 fn describe_dynamic_metrics() {
     let _guard = RECORDER.enter();
 
@@ -168,7 +165,6 @@ fn test_register(scope: &str) {
 }
 
 #[test]
-#[serial]
 fn register_metrics() {
     let _guard = RECORDER.enter();
 
@@ -178,7 +174,6 @@ fn register_metrics() {
 }
 
 #[test]
-#[serial]
 fn register_dynamic_metrics() {
     let _guard = RECORDER.enter();
 
@@ -218,7 +213,6 @@ fn test_labels(scope: &str) {
 }
 
 #[test]
-#[serial]
 fn label_metrics() {
     let _guard = RECORDER.enter();
 
@@ -228,7 +222,6 @@ fn label_metrics() {
 }
 
 #[test]
-#[serial]
 fn dynamic_label_metrics() {
     let _guard = RECORDER.enter();
 


### PR DESCRIPTION
Optimizes the generated code to call `metrics::with_recorder` only once per method instead of once per metric field.

## Changes

- Generate code that calls `with_recorder` once and registers all metrics inside that single closure
- Add `fn new()` with `OnceLock` caching for static scope, delegates to `new_with_labels`
- Add `describe()` with `Once`, delegates to `force_describe()`
- `new_with_labels()` always registers fresh (for re-registration or different labels)
- Generate `Clone` impl via `_clone()` helper method

## Before

Each metric field called `with_recorder` separately:

```rust
gauge: metrics::with_recorder(|r| r.register_gauge(...)),
counter: metrics::with_recorder(|r| r.register_counter(...)),
```

## After

Single `with_recorder` call per method:

```rust
metrics::with_recorder(|r| {
    Self {
        gauge: r.register_gauge(...),
        counter: r.register_counter(...),
    }
})
```